### PR TITLE
Fix markdown link rendering

### DIFF
--- a/src/app/games/games.module.ts
+++ b/src/app/games/games.module.ts
@@ -26,7 +26,7 @@ export function markedOptionsFactory(): MarkedOptions {
     return `<h${level} id="${id}">${text}</h${level}>`;
   };
   renderer.link = (href: string, title: string, text: string) => {
-    const hrefString = (href.startsWith("#") ? `href="${window.location.pathname}${href.replace(/\./,'')}"` : href );
+    const hrefString = (href.startsWith("#") ? `href="${window.location.pathname}${href.replace(/\./,'')}"` : `href="${href}"`);
     const titleString = ((!title || title.length === 0) ? "" : `title="${title}"`);
 
     return `<a ${hrefString} ${titleString}>${text}</a>`;

--- a/src/assets/md/mm_faq.md
+++ b/src/assets/md/mm_faq.md
@@ -146,7 +146,7 @@ How do I set up the decompilation on my computer?
 -------------------------------------------------
 
 See the instructions in the
-\[README.md\]https://github.com/zeldaret/mm/\#readme)
+[README.md](https://github.com/zeldaret/mm/\#readme)
 
 Why does the progress graph move so inconsistently?
 ---------------------------------------------------


### PR DESCRIPTION
This should fix the markdown links. I did run the server to make sure everything seemed to be working properly. I also fixed up the broken README link in the MM-faq.