### PR TITLE
Add Animal Forest's website

### DIFF
--- a/src/assets/json/games.json
+++ b/src/assets/json/games.json
@@ -130,8 +130,11 @@
   {
     "slug": "af",
     "title": "Animal Forest",
+    "routingURL": "https://zeldaret.github.io/af/",
+    "external": true,
     "links": {
-      "github": "https://github.com/zeldaret/af"
+      "github": "https://github.com/zeldaret/af",
+      "progress": "https://zeldaret.github.io/af/"
     },
     "shieldURL": "https://progress.decomp.club/data/animalforest/jp/code/?format=json&measure=all&mode=shield"
   },


### PR DESCRIPTION
I have it hosted on github pages. It's possible to use a custom domain with it so if later someone sets up a sub domain on the zeldaret site or something I could switch it to that