### PR TITLE
Add The Wind Waker progress website

### DIFF
--- a/src/assets/json/games.json
+++ b/src/assets/json/games.json
@@ -141,8 +141,11 @@
   {
     "slug": "tww",
     "title": "The Wind Waker",
+    "routingURL": "https://zeldaret.github.io/tww/",
+    "external": true,
     "links": {
-      "github": "https://github.com/zeldaret/tww"
+      "github": "https://github.com/zeldaret/tww",
+      "progress": "https://zeldaret.github.io/tww/"
     },
     "shieldURL": "https://progress.decomp.club/data/tww/GZLE01/all/?format=json&measure=code&mode=shield"
   },


### PR DESCRIPTION
Adds a link to the progress tracking website for TWW: https://zeldaret.github.io/tww/

Site source code available [here](https://github.com/LagoLunatic/tww-decomp-website) (which is forked from the BFBB decomp's website code, with some adjustments).