### PR TITLE
Switch shield URLs for dtk projects to use decomp.dev instead of decomp.club

### DIFF
--- a/src/assets/json/games.json
+++ b/src/assets/json/games.json
@@ -147,7 +147,7 @@
       "github": "https://github.com/zeldaret/tww",
       "progress": "https://zeldaret.github.io/tww/"
     },
-    "shieldURL": "https://progress.decomp.club/data/tww/GZLE01/all/?format=json&measure=code&mode=shield"
+    "shieldURL": "https://decomp.dev/zeldaret/tww.json?mode=shield"
   },
   {
     "slug": "tmc",
@@ -205,7 +205,7 @@
       "github": "https://github.com/zeldaret/tp",
       "progress": "https://zsrtp.link/progress"
     },
-    "shieldURL": "https://progress.decomp.club/data/twilightprincess/gcn_usa/default/?format=json&measure=code&mode=shield"
+    "shieldURL": "https://decomp.dev/zeldaret/tp.json?mode=shield"
   },
   {
     "slug": "ss",
@@ -213,7 +213,7 @@
     "links": {
       "github": "https://github.com/zeldaret/ss"
     },
-    "shieldURL": "https://progress.decomp.club/data/ss/SOUE01/all/?format=json&measure=code&mode=shield"
+    "shieldURL": "https://decomp.dev/zeldaret/ss.json?mode=shield"
   },
   {
     "slug": "botw",


### PR DESCRIPTION
Switch TWW, TP, and SS to show the progress percentages from decompal (https://decomp.dev/) instead of frogress (https://progress.decomp.club/data/).

This means the percentages are more accurate to how much of the code has actually been decompiled, counting work in unlinked TUs:
TWW: 17.38% -> 30.29%
TP: 44.90% -> 45.37%
SS: 3.77% -> 10.26%